### PR TITLE
Implement parser for string-based probability queries

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,6 +9,7 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
+            "elm/parser": "1.1.0",
             "elm/svg": "1.0.1",
             "elm-community/list-extra": "8.3.1",
             "elm-community/typed-svg": "7.0.0",
@@ -18,7 +19,6 @@
         "indirect": {
             "avh4/elm-color": "1.0.0",
             "elm/json": "1.1.3",
-            "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",

--- a/tests/ParserTests.elm
+++ b/tests/ParserTests.elm
@@ -1,0 +1,36 @@
+module ParserTests exposing (suite)
+
+import Expect
+import Main exposing (buffParser, dieParser, parser, probGenToTuple)
+import Parser exposing (run)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "Die parser test"
+        [ test "For 2d6" <|
+            \_ ->
+                run dieParser "2d6"
+                    |> Result.map probGenToTuple
+                    |> Result.withDefault ( 0, 0 )
+                    |> Expect.equal ( 2, 6 )
+        , test "For +1" <|
+            \_ ->
+                run buffParser "+1"
+                    |> Result.map probGenToTuple
+                    |> Result.withDefault ( 0, 0 )
+                    |> Expect.equal ( 1, 1 )
+        , test "For -3" <|
+            \_ ->
+                run buffParser "-3"
+                    |> Result.map probGenToTuple
+                    |> Result.withDefault ( 0, 0 )
+                    |> Expect.equal ( -3, 1 )
+        , test "For '2d6+4'" <|
+            \_ ->
+                run parser "2d6+4"
+                    |> Result.map (List.map probGenToTuple)
+                    |> Result.withDefault []
+                    |> Expect.equal [ ( 2, 6 ), ( 4, 1 ) ]
+        ]


### PR DESCRIPTION
Implemented parser.
Can't be reasonably used for charting until the data processing can handle negative number values.
Probably a problem with 282:
```
282    map (\( n, d ) -> List.repeat n d)
---
282    map (\( n, d ) -> List.repeat (abs n) (n // abs n * f))
```
Might have to pull a similar trick on 289 with `List.range`